### PR TITLE
Fix anonymizer production image build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,6 +57,17 @@ jobs:
       - name: Check and test inside Docker
         run: |
           docker run --rm "${{ env.IMAGE_NAME }}:${{ env.TEST_STAGE }}"
+      - name: Build production image for smoke test
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          target: "${{ env.PRODUCTION_STAGE }}"
+          tags: "${{ env.IMAGE_NAME }}:${{ env.PRODUCTION_STAGE }}"
+      - name: Smoke test production image
+        run: |
+          docker run --rm --entrypoint node "${{ env.IMAGE_NAME }}:${{ env.PRODUCTION_STAGE }}" \
+            -e "const fs = require('node:fs'); if (!fs.existsSync('/home/node/app/dist/index.js')) { throw new Error('Missing /home/node/app/dist/index.js'); }"
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-slim AS base
+FROM node:18-slim AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -42,7 +42,7 @@ RUN npm run build
 
 # The base image should be the same as the base image of base. Yet using ARG for
 # the base image irritates hadolint and might break Dependabot.
-FROM node:26-slim AS production
+FROM node:18-slim AS production
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- pin anonymizer Docker base and production images back to Node 18
- add a production-image smoke test that fails CI if `/home/node/app/dist/index.js` is missing

## Verification
- npm run check-and-build

This prevents the broken `edge` image issue from being republished unnoticed.